### PR TITLE
Play Slash Sound After Flash

### DIFF
--- a/FightingFaith/Assets/FlashDamage.cs
+++ b/FightingFaith/Assets/FlashDamage.cs
@@ -29,7 +29,7 @@ public class FlashDamage : MonoBehaviour
                     sp.material = defaultMaterial;
                 }
                 isFlashing = false;
-                
+                slashSound.Play();
                 timer = 0;
             }
         }
@@ -37,7 +37,7 @@ public class FlashDamage : MonoBehaviour
 
     public void FlashTrigger()
     {
-        slashSound.Play();
+      
         isFlashing = true;
         foreach(SpriteRenderer sp in spriteRenderers)
         {


### PR DESCRIPTION
Slash sound effect now plays after a flash completes, instead of being playing every time a flash is triggered. Flashes can be triggered frame after frame, but flashes can only complete after a timer has completed. This reduces the number of times slash sound is called.